### PR TITLE
✨ add dist to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "README.md",
     "index.js",
     "src/",
+    "dist",
     "package.json"
   ],
   "scripts": {


### PR DESCRIPTION
The library already provides non-module compatibility via dist.
The dist folder is not being published to npm. The only way to transpile to es5 is by installing the package via github instead of npm which is prone to errors

This PR publishes the dist folder to npm to allow users to import the library via /dist for es5